### PR TITLE
fix bug where mega menu wasnt showing all items

### DIFF
--- a/src/components/DropdownContent.jsx
+++ b/src/components/DropdownContent.jsx
@@ -7,6 +7,18 @@ const DropdownContent = ({
   handleClick,
 }) => {
   const [openSections, setOpenSections] = useState({});
+  const [isMobile, setIsMobile] = useState(false);
+
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia('(max-width: 768px)'); // Adjust this to match your hamburger breakpoint
+    const handleMediaQueryChange = () => setIsMobile(mediaQuery.matches);
+
+    handleMediaQueryChange(); // Set initial value
+    mediaQuery.addEventListener('change', handleMediaQueryChange);
+
+    return () => mediaQuery.removeEventListener('change', handleMediaQueryChange);
+  }, []);
 
   const toggleSection = (index) => {
     setOpenSections((prev) => ({
@@ -16,18 +28,20 @@ const DropdownContent = ({
   };
   return (
     <div className="dropdown_content">
-      {submenuscontent.map((item, index) => (
-        <React.Fragment key={index}>
-          <section>
-            <h4
-             style={{ cursor: 'pointer' }}
-            onClick={() => toggleSection(index)}
-            >{item.heading}</h4>
-            {openSections[index] && (
+    {submenuscontent.map((item, index) => (
+      <React.Fragment key={index}>
+        <section>
+          <h4
+            onClick={() => isMobile && toggleSection(index)} // Toggle only if mobile
+            style={{ cursor: isMobile ? 'pointer' : 'default' }} // Pointer cursor only on mobile
+          >
+            {item.heading}
+          </h4>
+          {(isMobile ? openSections[index] : true) && ( // Conditionally render `ul` based on `isMobile`
             <ul>
-              {item.submenu?.map(({ label, href }, index) => (
+              {item.submenu?.map(({ label, href }, idx) => (
                 <li
-                  key={index}
+                  key={idx}
                   onClick={() => {
                     setIsDrawerOpen && setIsDrawerOpen(false);
                     handleClick();
@@ -37,11 +51,11 @@ const DropdownContent = ({
                 </li>
               ))}
             </ul>
-            )}
-          </section>
-        </React.Fragment>
-      ))}
-    </div>
+          )}
+        </section>
+      </React.Fragment>
+    ))}
+  </div>
   );
 };
 


### PR DESCRIPTION
In the previous commit, I added a feature where the menu items are collapsible as to take up less space on the screen for mobile phones, This had a bug where it was happening on both phone screens and desktop, so the original mega menu didnt look as I expected it to. The collapsible functionality now only applies at screen sizes less than tablet size.

See pictures,

Before code change( what it isnt supposed to look like)
![mega menu broken](https://github.com/user-attachments/assets/e777dcbb-93cf-4554-977a-66c1d84a2f4f)

after code change

![mega menu fixed](https://github.com/user-attachments/assets/d5ce1fd5-4130-42b2-a7be-cc0c07b0fa9b)
Original feature that I was working on (mobile phone mega menu) 
![mobile phone feature](https://github.com/user-attachments/assets/759f2b33-f032-4a6d-b93d-92e97c3fd781)


